### PR TITLE
Ajuste para compatibilidade com python3

### DIFF
--- a/filepreviewfields/widgets.py
+++ b/filepreviewfields/widgets.py
@@ -11,7 +11,7 @@ class FilePreviewWidget(ClearableFileInput):
     def render(self, name, value, attrs=None):
         preview_html = self.get_preview_html(value)
         video = '<video src="%s%s" controls></video>' % (settings.MEDIA_URL, value) if value else ''
-        clear_class = ' hidden' if not hasattr(value, 'file') else ''
+        clear_class = ' hidden' if not value else ''
         output = '''
             <div class="filepreviewfield">
                 %(preview_html)s


### PR DESCRIPTION
No python3 o Django gera uma exception quando tentam acessar atributos de um FileField vazio.

A melhor forma é verificar se o field está preenchido antes:

```
if field:
    field.path
```